### PR TITLE
Update nimble_parsec to the latest (fixes compilation error)

### DIFF
--- a/lib/ex_sel/parser.ex
+++ b/lib/ex_sel/parser.ex
@@ -44,18 +44,21 @@ defmodule ExSel.Parser do
 
   vexpr_str =
     ignore(ascii_char([?"]))
-    |> repeat_until(
+    |> repeat_while(
       utf8_char([]),
-      [ascii_char([?"])]
+      {:not_quote, []}
     )
     |> ignore(ascii_char([?"]))
     |> reduce({List, :to_string, []})
     |> label("string")
 
+  defp not_quote(<<?", _::binary>>, context, _, _), do: {:halt, context}
+  defp not_quote(_, context, _, _), do: {:cont, context}
+
   vexpr_var =
     ascii_char([?a..?z])
     |> repeat(ascii_char([?a..?z, ?A..?Z, ?0..?9, ?_]))
-    |> traverse(:to_varname)
+    |> post_traverse(:to_varname)
     |> unwrap_and_tag(:var)
     |> label("variable")
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule ExSel.MixProject do
 
   defp deps do
     [
-      {:nimble_parsec, "~> 0.4"},
+      {:nimble_parsec, "~> 0.6.0"},
       {:stream_data, "~> 0.1", only: :test},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.18.0", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
-  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
-  "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm", "6c32a70ed5d452c6650916555b1f96c79af5fc4bf286997f8b15f213de786f73"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm", "c57508ddad47dfb8038ca6de1e616e66e9b87313220ac5d9817bc4a4dc2257b9"},
+  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "9dbe1ce1d711dc5362e3b3280e92989ad61413ce423bc4e9f76d5fcc51ab8d6b"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.6.0", "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm", "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},
+  "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm", "54d6bf6f1e5e27fbf4a7784a2bffbb993446d0efd079debca0f27bf859c0d1cf"},
 }


### PR DESCRIPTION
nimble_parsec 0.5.0 removed `repeat_until/3` and deprecated `traverse/3`:
https://github.com/dashbitco/nimble_parsec/blob/ca8f52b7c7aaafafd1fc0029e9cc88f204aaaeae/CHANGELOG.md#v050-2018-12-12

Also made the version of nimble_parsec more restrictive since it's not guaranteed to have non-breaking changes between minor versions until it reaches 1.0.